### PR TITLE
Remove `ruby-head` from build matrix

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,20 +3,15 @@ on: [push]
 jobs:
   check:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allow-failures }}
     strategy:
       matrix:
         ruby: [ 2.7, 3.0 ]
-        allow-failures: [ false ]
-        include:
-          - ruby: head
-            allow-failures: true
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: ${{ matrix.ruby }}
     - name: Build and test with Rake
       env:
         DO_ACCESS_TOKEN: ${{ secrets.DO_ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## unreleased (master)
 
+### Changes
+
+* Remove `ruby-head` from test matrix
+
+### Fixes
+
+* Fix incorrect setting ruby version in build matrix
+
 ## 0.6.0 (2021-02-11)
 
 ### New Features


### PR DESCRIPTION
Current variant cause DO api banning from usage after single run
Remove one element from matrix may help, but may not,
need to test it