### PR TITLE
Fix missing `ostruct` dependency for `ruby-head` (future `ruby-3.5`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased (master)
 
+### Fixes
+
+* Fix missing `ostruct` dependency for `ruby-head` (future `ruby-3.5`)
+
 ### New Features
 
 * Add `ruby-3.4` to CI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     onlyoffice_digitalocean_wrapper (0.9.0)
       droplet_kit (~> 3)
       net-telnet (~> 0)
+      ostruct (~> 0)
 
 GEM
   remote: https://rubygems.org/
@@ -48,6 +49,7 @@ GEM
     net-http (0.6.0)
       uri
     net-telnet (0.2.0)
+    ostruct (0.6.1)
     overcommit (0.64.1)
       childprocess (>= 0.6.3, < 6)
       iniparse (~> 1.4)
@@ -133,4 +135,4 @@ DEPENDENCIES
   yard (>= 0.9.20)
 
 BUNDLED WITH
-   2.5.16
+   2.6.3

--- a/onlyoffice_digitalocean_wrapper.gemspec
+++ b/onlyoffice_digitalocean_wrapper.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |s|
   s.license = 'AGPL-3.0'
   s.add_dependency('droplet_kit', '~> 3')
   s.add_dependency('net-telnet', '~> 0')
+  # Until https://github.com/digitalocean/droplet_kit/pull/333 is released
+  s.add_dependency('ostruct', '~> 0')
 end


### PR DESCRIPTION
Fix https://github.com/ONLYOFFICE-QA/onlyoffice_digitalocean_wrapper/issues/660